### PR TITLE
Fix pg_stat_statements compatibility

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -91,6 +91,7 @@ GEM
     marcel (1.0.2)
     method_source (1.0.0)
     mini_mime (1.1.2)
+    mini_portile2 (2.7.1)
     minitest (5.15.0)
     net-imap (0.2.3)
       digest
@@ -108,6 +109,9 @@ GEM
       net-protocol
       timeout
     nio4r (2.5.8)
+    nokogiri (1.13.1)
+      mini_portile2 (~> 2.7.0)
+      racc (~> 1.4)
     nokogiri (1.13.1-x86_64-linux)
       racc (~> 1.4)
     pg (1.3.1)

--- a/test/dummy/db/migrate/20230607072750_enable_pg_stat_statements.rb
+++ b/test/dummy/db/migrate/20230607072750_enable_pg_stat_statements.rb
@@ -1,0 +1,5 @@
+class EnablePgStatStatements < ActiveRecord::Migration[7.0]
+  def change
+    enable_extension 'pg_stat_statements'
+  end
+end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,9 +10,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_02_15_124409) do
+ActiveRecord::Schema.define(version: 2023_06_07_072750) do
 
   # These are extensions that must be enabled in order to support this database
+  enable_extension "pg_stat_statements"
   enable_extension "plpgsql"
 
   create_table "accounts", force: :cascade do |t|
@@ -47,7 +48,7 @@ ActiveRecord::Schema.define(version: 2022_02_15_124409) do
 
 
   create_sql_view "active_account_views", sql: <<-SQL
-    CREATE  VIEW "active_account_views" AS
+    CREATE VIEW "active_account_views" AS
        SELECT accounts.id,
       accounts.name,
       accounts.active,
@@ -58,7 +59,7 @@ ActiveRecord::Schema.define(version: 2022_02_15_124409) do
   SQL
 
   create_sql_view "deleted_account_views", sql: <<-SQL
-    CREATE  MATERIALIZED  VIEW "deleted_account_views" AS
+    CREATE MATERIALIZED VIEW "deleted_account_views" AS
        SELECT accounts.id,
       accounts.name,
       accounts.active,
@@ -69,7 +70,7 @@ ActiveRecord::Schema.define(version: 2022_02_15_124409) do
   SQL
 
   create_sql_view "bulgaria_views", sql: <<-SQL
-    CREATE  MATERIALIZED  VIEW "bulgaria_views" AS
+    CREATE MATERIALIZED VIEW "bulgaria_views" AS
        SELECT users.id,
       users.name,
       users.country,
@@ -80,7 +81,7 @@ ActiveRecord::Schema.define(version: 2022_02_15_124409) do
   SQL
 
   create_sql_view "monther_anna_views", sql: <<-SQL
-    CREATE  VIEW "monther_anna_views" AS
+    CREATE VIEW "monther_anna_views" AS
        SELECT parents.id,
       parents.name,
       parents.type,
@@ -91,7 +92,7 @@ ActiveRecord::Schema.define(version: 2022_02_15_124409) do
   SQL
 
   create_sql_view "active_worker_views", sql: <<-SQL
-    CREATE  VIEW "active_worker_views" AS
+    CREATE VIEW "active_worker_views" AS
        SELECT workers.id,
       workers.title,
       workers.jobable_id,
@@ -102,7 +103,7 @@ ActiveRecord::Schema.define(version: 2022_02_15_124409) do
   SQL
 
   create_sql_view "active_user_views", sql: <<-SQL
-    CREATE  MATERIALIZED  VIEW "active_user_views" AS
+    CREATE MATERIALIZED VIEW "active_user_views" AS
        SELECT users.id,
       users.name,
       users.country,


### PR DESCRIPTION
Updated views querying code to be similar to [scenic's](https://github.com/scenic-views/scenic/blob/be0980db1023feca2da17a55a68ff0fcad8bf2e6/lib/scenic/adapters/postgres/views.rb#L25), since pg_stat_statements extension is adding some views to the schema
Also, did some minor improvements like removing duplicate space in schema dump